### PR TITLE
New variable to use an app inference profile instead of creating a new one for each agent #131

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -35,21 +35,29 @@ data "aws_iam_policy_document" "agent_permissions" {
   count = var.create_agent || var.create_supervisor ? 1 : 0
   statement {
     actions = [
-      "bedrock:InvokeModel*",
-      "bedrock:UseInferenceProfile",
+      "bedrock:InvokeModel*", // FOR "bedrock:InvokeModel" and "bedrock:InvokeModelWithResponseStream",
+      "bedrock:UseInferenceProfile", // "bedrock:GetInferenceProfile",
     ]
     resources = distinct(concat(
+      var.use_app_inference_profile ? [
+        var.app_inference_profile_model_source,
+        # "arn:aws:bedrock:eu-west-1:915193162015:inference-profile/eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "arn:aws:bedrock:*::foundation-model/*", // TOO BROAD, but needed 
+        # "arn:aws:bedrock:*:*:application-inference-profile/*",
+      ] : [],
       var.create_app_inference_profile ? [
        var.app_inference_profile_model_source,
        awscc_bedrock_application_inference_profile.application_inference_profile[0].inference_profile_arn,
        "arn:aws:bedrock:*:*:application-inference-profile/*",
-      ] : [
+      ] : [],
+      var.create_app_inference_profile ? 
+        awscc_bedrock_application_inference_profile.application_inference_profile[0].models[*].model_arn : [],
+      !var.create_app_inference_profile && !var.use_app_inference_profile ? 
+      [
        "arn:${local.partition}:bedrock:${local.region}::foundation-model/${local.foundation_model}",
        "arn:${local.partition}:bedrock:*::foundation-model/${local.foundation_model}",
        "arn:${local.partition}:bedrock:${local.region}:${local.account_id}:inference-profile/*.${local.foundation_model}",
-      ],
-      var.create_app_inference_profile ? 
-        awscc_bedrock_application_inference_profile.application_inference_profile[0].models[*].model_arn : []
+      ]: []
     ))
   }
 }
@@ -100,7 +108,9 @@ data "aws_iam_policy_document" "custom_model_trust" {
 }
 
 data "aws_iam_policy_document" "app_inference_profile_permission" {
-  count = var.create_app_inference_profile ? 1 : 0
+  # Is it needed ?
+  count = var.create_app_inference_profile || var.use_app_inference_profile ? 1 : 0
+  # count = var.create_app_inference_profile ? 1 : 0
   statement {
     actions = [
       "bedrock:GetInferenceProfile",

--- a/iam.tf
+++ b/iam.tf
@@ -263,7 +263,7 @@ resource "aws_iam_role_policy" "action_group_policy" {
 
 # Define the IAM role for Application Inference Profile
 resource "aws_iam_role" "application_inference_profile_role" {
-  count = var.create_app_inference_profile ? 1 : 0
+  count = var.create_app_inference_profile || var.use_app_inference_profile ? 1 : 0
   name  = "ApplicationInferenceProfile-${random_string.solution_prefix.result}"
 
   assume_role_policy = jsonencode({
@@ -282,7 +282,8 @@ resource "aws_iam_role" "application_inference_profile_role" {
 }
 
 resource "aws_iam_role_policy" "app_inference_profile_role_policy" {
-  count = var.create_app_inference_profile ? 1 : 0
+  # count = var.create_app_inference_profile ? 1 : 0
+  count  = var.create_app_inference_profile || var.use_app_inference_profile ? 1 : 0
   policy = jsonencode({
     "Version": "2012-10-17",
     "Statement": [

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,8 @@ resource "time_sleep" "wait_for_inference_profile" {
 resource "awscc_bedrock_agent" "bedrock_agent" {
   count                       = var.create_agent ? 1 : 0
   agent_name                  = "${random_string.solution_prefix.result}-${var.agent_name}"
-  foundation_model            = var.create_app_inference_profile ? awscc_bedrock_application_inference_profile.application_inference_profile[0].inference_profile_arn : var.foundation_model
+  foundation_model            = var.use_app_inference_profile ? var.app_inference_profile_model_source : var.foundation_model
+  // var.create_app_inference_profile ? awscc_bedrock_application_inference_profile.application_inference_profile[0].inference_profile_arn : var.foundation_model
   instruction                 = var.instruction
   description                 = var.agent_description
   idle_session_ttl_in_seconds = var.idle_session_ttl
@@ -164,7 +165,8 @@ resource "aws_bedrockagent_agent" "agent_supervisor" {
 
   agent_collaboration         = var.agent_collaboration
   idle_session_ttl_in_seconds = var.supervisor_idle_session_ttl
-  foundation_model            = var.create_app_inference_profile ? awscc_bedrock_application_inference_profile.application_inference_profile[0].inference_profile_arn : var.supervisor_model
+  foundation_model            = var.use_app_inference_profile ? var.app_inference_profile_model_source : var.foundation_model
+  // foundation_model            = var.create_app_inference_profile ? awscc_bedrock_application_inference_profile.application_inference_profile[0].inference_profile_arn : var.supervisor_model
   instruction                 = var.supervisor_instruction
   customer_encryption_key_arn = var.supervisor_kms_key_arn
   #checkov:skip=CKV_AWS_383:The user can optionally associate agent with Bedrock guardrails

--- a/variables.tf
+++ b/variables.tf
@@ -1124,6 +1124,12 @@ variable "create_app_inference_profile" {
   default     = false
 }
 
+variable "use_app_inference_profile" {
+  description = "Whether or not to create an application inference profile."
+  type        = bool
+  default     = false
+}
+
 variable "app_inference_profile_name" {
   description = "The name of your application inference profile."
   type        = string


### PR DESCRIPTION
Summary : add a new variable to use an app inference profile instead of creating a new one.
The actual behaviour of the module require each agents to create a new inference profile.

Desired output :
This variable use_app_inference_profile to true should make the agent attach to the inference profile defined in the existing variable : app_inference_profile_model_source

Tested with a standard inference profile activated on aws for the foundation model sonnet.3.7.